### PR TITLE
Allow murmur2 to be used with a stream

### DIFF
--- a/benches/murmurhash32_bench.rs
+++ b/benches/murmurhash32_bench.rs
@@ -5,14 +5,22 @@ use criterion::Criterion;
 use murmurhash32::{murmurhash2, murmurhash3};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("murmurhash2 5", |b| b.iter(|| criterion::black_box(murmurhash2(b"turtl"))));
-    c.bench_function("murmurhash2 10", |b| b.iter(|| criterion::black_box(murmurhash2(b"liketurtles"))));
+    c.bench_function("murmurhash2 5", |b| {
+        b.iter(|| criterion::black_box(murmurhash2(b"turtl")))
+    });
+    c.bench_function("murmurhash2 10", |b| {
+        b.iter(|| criterion::black_box(murmurhash2(b"liketurtles")))
+    });
     c.bench_function("murmurhash2 15", |b| {
         b.iter(|| criterion::black_box(murmurhash2(b"i like turtles!")))
     });
     c.bench_function("murmurhash2 100", |b| b.iter(|| criterion::black_box(murmurhash2(b"maitre corbeau sur un arbre perche tenait dans son bec un fromage. Maitre renard par l'odeur alleche"))));
-    c.bench_function("murmurhash3 5", |b| b.iter(|| criterion::black_box(murmurhash3(b"turtl"))));
-    c.bench_function("murmurhash3 10", |b| b.iter(|| criterion::black_box(murmurhash3(b"liketurtles"))));
+    c.bench_function("murmurhash3 5", |b| {
+        b.iter(|| criterion::black_box(murmurhash3(b"turtl")))
+    });
+    c.bench_function("murmurhash3 10", |b| {
+        b.iter(|| criterion::black_box(murmurhash3(b"liketurtles")))
+    });
     c.bench_function("murmurhash3 15", |b| {
         b.iter(|| criterion::black_box(murmurhash3(b"i like turtles!")))
     });

--- a/benches/murmurhash32_bench.rs
+++ b/benches/murmurhash32_bench.rs
@@ -5,18 +5,18 @@ use criterion::Criterion;
 use murmurhash32::{murmurhash2, murmurhash3};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("murmurhash2 5", |b| b.iter(|| murmurhash2(b"turtl")));
-    c.bench_function("murmurhash2 10", |b| b.iter(|| murmurhash2(b"liketurtles")));
+    c.bench_function("murmurhash2 5", |b| b.iter(|| criterion::black_box(murmurhash2(b"turtl"))));
+    c.bench_function("murmurhash2 10", |b| b.iter(|| criterion::black_box(murmurhash2(b"liketurtles"))));
     c.bench_function("murmurhash2 15", |b| {
-        b.iter(|| murmurhash2(b"i like turtles!"))
+        b.iter(|| criterion::black_box(murmurhash2(b"i like turtles!")))
     });
-    c.bench_function("murmurhash2 100", |b| b.iter(|| murmurhash2(b"maitre corbeau sur un arbre perche tenait dans son bec un fromage. Maitre renard par l'odeur alleche")));
-    c.bench_function("murmurhash3 5", |b| b.iter(|| murmurhash3(b"turtl")));
-    c.bench_function("murmurhash3 10", |b| b.iter(|| murmurhash3(b"liketurtles")));
+    c.bench_function("murmurhash2 100", |b| b.iter(|| criterion::black_box(murmurhash2(b"maitre corbeau sur un arbre perche tenait dans son bec un fromage. Maitre renard par l'odeur alleche"))));
+    c.bench_function("murmurhash3 5", |b| b.iter(|| criterion::black_box(murmurhash3(b"turtl"))));
+    c.bench_function("murmurhash3 10", |b| b.iter(|| criterion::black_box(murmurhash3(b"liketurtles"))));
     c.bench_function("murmurhash3 15", |b| {
-        b.iter(|| murmurhash3(b"i like turtles!"))
+        b.iter(|| criterion::black_box(murmurhash3(b"i like turtles!")))
     });
-    c.bench_function("murmurhash3 100", |b| b.iter(|| murmurhash3(b"maitre corbeau sur un arbre perche tenait dans son bec un fromage. Maitre renard par l'odeur alleche")));
+    c.bench_function("murmurhash3 100", |b| b.iter(|| criterion::black_box(murmurhash3(b"maitre corbeau sur un arbre perche tenait dans son bec un fromage. Maitre renard par l'odeur alleche"))));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod murmurhash2;
 mod murmurhash3;
 
 pub use self::murmurhash2::murmurhash2;
+pub use self::murmurhash2::Murmur2Digest;
 pub use self::murmurhash3::murmurhash3;
 
 #[cfg(test)]

--- a/src/murmurhash2.rs
+++ b/src/murmurhash2.rs
@@ -1,47 +1,91 @@
-use byteorder::{ByteOrder, LittleEndian};
-
 const SEED: u32 = 1;
 const M: u32 = 0x5bd1_e995;
 
 pub fn murmurhash2(key: &[u8]) -> u32 {
-    let mut h: u32 = SEED ^ (key.len() as u32);
-
-    let mut four_bytes_chunks = key.chunks_exact(4);
-
-    while let Some(chunk) = four_bytes_chunks.next() {
-        let mut k: u32 = LittleEndian::read_u32(chunk);
-        k = k.wrapping_mul(M);
-        k ^= k >> 24;
-        k = k.wrapping_mul(M);
-        h = h.wrapping_mul(M);
-        h ^= k;
-    }
-    let remainder = four_bytes_chunks.remainder();
-
-    // Handle the last few bytes of the input array
-    match remainder.len() {
-        3 => {
-            h ^= u32::from(remainder[2]) << 16;
-            h ^= u32::from(remainder[1]) << 8;
-            h ^= u32::from(remainder[0]);
-            h = h.wrapping_mul(M);
-        }
-        2 => {
-            h ^= u32::from(remainder[1]) << 8;
-            h ^= u32::from(remainder[0]);
-            h = h.wrapping_mul(M);
-        }
-        1 => {
-            h ^= u32::from(remainder[0]);
-            h = h.wrapping_mul(M);
-        }
-        _ => {}
-    }
-    h ^= h >> 13;
-    h = h.wrapping_mul(M);
-    h ^ (h >> 15)
+    Murmur2Digest::digest(key)
 }
 
+pub struct Murmur2Digest {
+		hash: u32,
+		remainder: [u8; 3],
+		remainder_length: usize,
+}
+
+impl Murmur2Digest {
+		pub fn digest(data: &[u8]) -> u32 {
+				let mut digest = Self::new(data.len() as u32);
+				digest.update(data);
+				digest.finalize()
+		}
+
+		pub fn new(length: u32) -> Self {
+				Self {
+						hash: SEED ^ length,
+						remainder: [0; 3],
+						remainder_length: 0,
+				}
+		}
+
+		#[inline]
+		pub fn update(&mut self, mut data: &[u8]) {
+				let combined_len = data.len() + self.remainder_length as usize;
+
+				if combined_len >= 4 {
+						let mut chunk = [0u8; 4];
+						let rl = self.remainder_length as usize;
+						chunk[..rl].copy_from_slice(&self.remainder[..rl]);
+						chunk[rl..].copy_from_slice(&data[..4 - rl]);
+						data = &data[4 - rl..];
+						self.update_chunk(chunk);
+				}
+
+				while data.len() >= 4 {
+						let chunk = std::array::from_fn(|i| data[i]);
+						self.update_chunk(chunk);
+						data = &data[4..];
+				}
+
+				let remlen = combined_len % 4;
+
+				self.remainder[..remlen].copy_from_slice(data);
+				self.remainder_length = remlen;
+		}
+
+		#[inline]
+		fn update_chunk(&mut self, chunk: [u8; 4]) {
+				let mut k = u32::from_le_bytes(chunk);
+				k = k.wrapping_mul(M);
+				k ^= k >> 24;
+				k = k.wrapping_mul(M);
+				self.hash = self.hash.wrapping_mul(M);
+				self.hash ^= k;
+		}
+
+		pub fn finalize(mut self) -> u32 {
+				match self.remainder_length {
+						3 => {
+								self.hash ^= u32::from(self.remainder[2]) << 16;
+								self.hash ^= u32::from(self.remainder[1]) << 8;
+								self.hash ^= u32::from(self.remainder[0]);
+								self.hash = self.hash.wrapping_mul(M);
+						}
+						2 => {
+								self.hash ^= u32::from(self.remainder[1]) << 8;
+								self.hash ^= u32::from(self.remainder[0]);
+								self.hash = self.hash.wrapping_mul(M);
+						}
+						1 => {
+								self.hash ^= u32::from(self.remainder[0]);
+								self.hash = self.hash.wrapping_mul(M);
+						}
+						_ => {}
+				}
+
+				self.hash ^= self.hash >> 13;
+				self.hash = self.hash.wrapping_mul(M);
+				self.hash ^ (self.hash >> 15)
+		}
+}
 
 #[cfg(test)]
 mod test {

--- a/src/murmurhash2.rs
+++ b/src/murmurhash2.rs
@@ -6,85 +6,85 @@ pub fn murmurhash2(key: &[u8]) -> u32 {
 }
 
 pub struct Murmur2Digest {
-		hash: u32,
-		remainder: [u8; 3],
-		remainder_length: usize,
+    hash: u32,
+    remainder: [u8; 3],
+    remainder_length: usize,
 }
 
 impl Murmur2Digest {
-		pub fn digest(data: &[u8]) -> u32 {
-				let mut digest = Self::new(data.len() as u32);
-				digest.update(data);
-				digest.finalize()
-		}
+    pub fn digest(data: &[u8]) -> u32 {
+        let mut digest = Self::new(data.len() as u32);
+        digest.update(data);
+        digest.finalize()
+    }
 
-		pub fn new(length: u32) -> Self {
-				Self {
-						hash: SEED ^ length,
-						remainder: [0; 3],
-						remainder_length: 0,
-				}
-		}
+    pub fn new(length: u32) -> Self {
+        Self {
+            hash: SEED ^ length,
+            remainder: [0; 3],
+            remainder_length: 0,
+        }
+    }
 
-		#[inline]
-		pub fn update(&mut self, mut data: &[u8]) {
-				let combined_len = data.len() + self.remainder_length as usize;
+    #[inline]
+    pub fn update(&mut self, mut data: &[u8]) {
+        let combined_len = data.len() + self.remainder_length as usize;
 
-				if combined_len >= 4 {
-						let mut chunk = [0u8; 4];
-						let rl = self.remainder_length as usize;
-						chunk[..rl].copy_from_slice(&self.remainder[..rl]);
-						chunk[rl..].copy_from_slice(&data[..4 - rl]);
-						data = &data[4 - rl..];
-						self.update_chunk(chunk);
-				}
+        if combined_len >= 4 {
+            let mut chunk = [0u8; 4];
+            let rl = self.remainder_length as usize;
+            chunk[..rl].copy_from_slice(&self.remainder[..rl]);
+            chunk[rl..].copy_from_slice(&data[..4 - rl]);
+            data = &data[4 - rl..];
+            self.update_chunk(chunk);
+        }
 
-				while data.len() >= 4 {
-						let chunk = std::array::from_fn(|i| data[i]);
-						self.update_chunk(chunk);
-						data = &data[4..];
-				}
+        while data.len() >= 4 {
+            let chunk = std::array::from_fn(|i| data[i]);
+            self.update_chunk(chunk);
+            data = &data[4..];
+        }
 
-				let remlen = combined_len % 4;
+        let remlen = combined_len % 4;
 
-				self.remainder[..remlen].copy_from_slice(data);
-				self.remainder_length = remlen;
-		}
+        self.remainder[..remlen].copy_from_slice(data);
+        self.remainder_length = remlen;
+    }
 
-		#[inline]
-		fn update_chunk(&mut self, chunk: [u8; 4]) {
-				let mut k = u32::from_le_bytes(chunk);
-				k = k.wrapping_mul(M);
-				k ^= k >> 24;
-				k = k.wrapping_mul(M);
-				self.hash = self.hash.wrapping_mul(M);
-				self.hash ^= k;
-		}
+    #[inline]
+    fn update_chunk(&mut self, chunk: [u8; 4]) {
+        let mut k = u32::from_le_bytes(chunk);
+        k = k.wrapping_mul(M);
+        k ^= k >> 24;
+        k = k.wrapping_mul(M);
+        self.hash = self.hash.wrapping_mul(M);
+        self.hash ^= k;
+    }
 
-		pub fn finalize(mut self) -> u32 {
-				match self.remainder_length {
-						3 => {
-								self.hash ^= u32::from(self.remainder[2]) << 16;
-								self.hash ^= u32::from(self.remainder[1]) << 8;
-								self.hash ^= u32::from(self.remainder[0]);
-								self.hash = self.hash.wrapping_mul(M);
-						}
-						2 => {
-								self.hash ^= u32::from(self.remainder[1]) << 8;
-								self.hash ^= u32::from(self.remainder[0]);
-								self.hash = self.hash.wrapping_mul(M);
-						}
-						1 => {
-								self.hash ^= u32::from(self.remainder[0]);
-								self.hash = self.hash.wrapping_mul(M);
-						}
-						_ => {}
-				}
+    pub fn finalize(mut self) -> u32 {
+        match self.remainder_length {
+            3 => {
+                self.hash ^= u32::from(self.remainder[2]) << 16;
+                self.hash ^= u32::from(self.remainder[1]) << 8;
+                self.hash ^= u32::from(self.remainder[0]);
+                self.hash = self.hash.wrapping_mul(M);
+            }
+            2 => {
+                self.hash ^= u32::from(self.remainder[1]) << 8;
+                self.hash ^= u32::from(self.remainder[0]);
+                self.hash = self.hash.wrapping_mul(M);
+            }
+            1 => {
+                self.hash ^= u32::from(self.remainder[0]);
+                self.hash = self.hash.wrapping_mul(M);
+            }
+            _ => {}
+        }
 
-				self.hash ^= self.hash >> 13;
-				self.hash = self.hash.wrapping_mul(M);
-				self.hash ^ (self.hash >> 15)
-		}
+        self.hash ^= self.hash >> 13;
+        self.hash = self.hash.wrapping_mul(M);
+        self.hash ^ (self.hash >> 15)
+    }
 }
 
 #[cfg(test)]

--- a/src/murmurhash3.rs
+++ b/src/murmurhash3.rs
@@ -78,5 +78,4 @@ mod test {
         assert_eq!(murmurhash3(b"abcde"), 2_747_833_956);
         assert_eq!(murmurhash3(b"abcdefghijklmnop"), 2_078_305_053);
     }
-
 }


### PR DESCRIPTION
Now slightly slower but can be used as a stream provided you know the length upfront.

Note: the tests didn't pass to begin with but all the new results match the old results.